### PR TITLE
Fix environment variable

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -9,7 +9,7 @@ export
 
 # set a variable pointing to the bare repo
 # we cannot work against the checkout, since it is a archive without .git
-declare -x BARE_REPO="$HOME/git/$OPENSHIFT_APP_NAME.git"
+declare -x BARE_REPO="$OPENSHIFT_HOMEDIR/git/$OPENSHIFT_APP_NAME.git"
 
 # Gollum needs the git repo in its configuration. Using Perl and in place regular
 # expression replacement we get the right value into config.ru. 


### PR DESCRIPTION
An updated in OpenShift configuration changed the $HOME environment variable from $HOME to $OPENSHIFT_HOMEDIR

The fix permits to solve the following error when deploying

```
remote: /var/lib/openshift/477155af8f6b4938b1ebff4e6e801e9f/app-root/runtime/repo/.openshift/action_hooks/build: line 18: cd: /git/jbosswiki.git: No such file or directory
remote: /var/lib/openshift/477155af8f6b4938b1ebff4e6e801e9f/app-root/runtime/repo/.openshift/action_hooks/build: line 20: config: Permission denied
remote: /var/lib/openshift/477155af8f6b4938b1ebff4e6e801e9f/app-root/runtime/repo/.openshift/action_hooks/build: line 21: config: Permission denied
remote: /var/lib/openshift/477155af8f6b4938b1ebff4e6e801e9f/app-root/runtime/repo/.openshift/action_hooks/build: line 22: config: Permission denied
remote: An error occurred executing 'gear postreceive'
```
